### PR TITLE
Enhance auth flow and profile UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,6 +62,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
+    "formik": "^2.4.2",
     "zod": "^3.23.8",
     "graphql": "^16.8.0",
     "@apollo/client": "^3.8.0"

--- a/apps/web/src/app/[locale]/login/page.tsx
+++ b/apps/web/src/app/[locale]/login/page.tsx
@@ -1,67 +1,165 @@
 "use client";
 
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { useLoginMutation } from "@/generated/graphql";
+import { useRouter } from "next/navigation";
+import { useFormik } from "formik";
+import { z } from "zod";
+
+const LoginSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(1, "Password is required"),
+});
+
+type LoginValues = z.infer<typeof LoginSchema>;
 
 export default function LoginPage() {
-  const [formData, setFormData] = useState({ email: "", password: "" });
+  const [showPassword, setShowPassword] = useState(false);
   const [login, { loading, error }] = useLoginMutation();
+  const router = useRouter();
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      const { data } = await login({
-        variables: { email: formData.email, password: formData.password },
-      });
-      if (data?.login.access_token) {
-        localStorage.setItem("access_token", data.login.access_token);
-        window.location.href = "/profile";
+  const formik = useFormik<LoginValues>({
+    initialValues: { email: "", password: "" },
+    validate: (values) => {
+      const result = LoginSchema.safeParse(values);
+      if (result.success) return {};
+      const errors: Record<string, string> = {};
+      for (const issue of result.error.issues) {
+        const key = issue.path[0] as string;
+        if (!errors[key]) errors[key] = issue.message;
       }
-    } catch (err) {
-      console.error(err);
-    }
-  };
+      return errors;
+    },
+    onSubmit: async (values) => {
+      try {
+        const { data } = await login({
+          variables: { email: values.email, password: values.password },
+        });
+        if (data?.login.access_token) {
+          localStorage.setItem("access_token", data.login.access_token);
+          router.push("/profile");
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    },
+  });
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("animate-fade-in");
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+
+    const elements = document.querySelectorAll(".animate-on-scroll");
+    elements.forEach((el) => observer.observe(el));
+
+    return () => {
+      elements.forEach((el) => observer.unobserve(el));
+    };
+  }, []);
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen">
       <Navbar />
-      <main className="flex-1 flex items-center justify-center p-4">
-        <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
-          <h1 className="text-2xl font-bold text-center">Login</h1>
-          <input
-            type="email"
-            name="email"
-            placeholder="Email"
-            value={formData.email}
-            onChange={handleChange}
-            className="w-full px-4 py-2 border rounded"
-            required
-          />
-          <input
-            type="password"
-            name="password"
-            placeholder="Password"
-            value={formData.password}
-            onChange={handleChange}
-            className="w-full px-4 py-2 border rounded"
-            required
-          />
-          {error && <p className="text-red-500 text-sm">{error.message}</p>}
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-pulse-500 text-white py-2 rounded"
-          >
-            {loading ? "Logging in..." : "Login"}
-          </button>
-        </form>
+      <main className="pt-20">
+        <section
+          className="overflow-hidden relative bg-cover"
+          style={{
+            backgroundImage: 'url("/Header-background.webp")',
+            backgroundPosition: "center 30%",
+            padding: "60px 12px 40px",
+          }}
+        >
+          <div className="container px-4 sm:px-6 lg:px-8">
+            <div className="max-w-md mx-auto">
+              <h1 className="section-title text-3xl sm:text-4xl mb-6 opacity-0 animate-fade-in text-center">
+                Welcome Back
+              </h1>
+              <div className="glass-card p-6 sm:p-8 opacity-0 animate-fade-in" style={{ animationDelay: "0.2s" }}>
+                <form onSubmit={formik.handleSubmit} className="space-y-6">
+                  <div>
+                    <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                      Email
+                    </label>
+                    <input
+                      type="email"
+                      id="email"
+                      name="email"
+                      value={formik.values.email}
+                      onChange={formik.handleChange}
+                      onBlur={formik.handleBlur}
+                      className={`w-full px-4 py-3 border rounded-lg focus:ring-2 focus:ring-pulse-500 focus:border-transparent transition-all duration-300 ${
+                        formik.touched.email && formik.errors.email ? "border-red-500" : "border-gray-300"
+                      }`}
+                      placeholder="you@example.com"
+                    />
+                    {formik.touched.email && formik.errors.email && (
+                      <p className="mt-1 text-sm text-red-600">{formik.errors.email}</p>
+                    )}
+                  </div>
+                  <div>
+                    <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+                      Password
+                    </label>
+                    <div className="relative">
+                      <input
+                        type={showPassword ? "text" : "password"}
+                        id="password"
+                        name="password"
+                        value={formik.values.password}
+                        onChange={formik.handleChange}
+                        onBlur={formik.handleBlur}
+                        className={`w-full px-4 py-3 pr-12 border rounded-lg focus:ring-2 focus:ring-pulse-500 focus:border-transparent transition-all duration-300 ${
+                          formik.touched.password && formik.errors.password ? "border-red-500" : "border-gray-300"
+                        }`}
+                        placeholder="••••••••"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                      >
+                        {showPassword ? <span className="sr-only">Hide</span> : <span className="sr-only">Show</span>}
+                      </button>
+                    </div>
+                    {formik.touched.password && formik.errors.password && (
+                      <p className="mt-1 text-sm text-red-600">{formik.errors.password}</p>
+                    )}
+                  </div>
+                  {error && <p className="text-red-500 text-sm">{error.message}</p>}
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    className="flex items-center justify-center group w-full text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                    style={{
+                      backgroundColor: "#FE5C02",
+                      borderRadius: "1440px",
+                      boxSizing: "border-box",
+                      color: "#FFFFFF",
+                      cursor: "pointer",
+                      fontSize: "14px",
+                      lineHeight: "20px",
+                      padding: "16px 24px",
+                      border: "1px solid white",
+                    }}
+                  >
+                    {loading ? "Logging in..." : "Login"}
+                  </button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
       <Footer />
     </div>

--- a/apps/web/src/app/[locale]/profile/page.tsx
+++ b/apps/web/src/app/[locale]/profile/page.tsx
@@ -1,18 +1,55 @@
 "use client";
 
+import { useState } from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { UserProfile } from "@/components/UserProfile";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarInset,
+} from "@/components/ui/sidebar";
 
 export default function ProfilePage() {
+  const [active, setActive] = useState("profile");
+
   return (
     <ProtectedRoute>
       <div className="min-h-screen flex flex-col">
         <Navbar />
-        <main className="flex-1 container mx-auto py-8">
-          <UserProfile />
-        </main>
+        <SidebarProvider>
+          <div className="flex flex-1 pt-16">
+            <Sidebar className="bg-sidebar">
+              <SidebarContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton isActive={active === "profile"} onClick={() => setActive("profile")}>Profile</SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton isActive={active === "settings"} onClick={() => setActive("settings")}>Settings</SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton isActive={active === "billing"} onClick={() => setActive("billing")}>Billing</SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarContent>
+            </Sidebar>
+            <SidebarInset className="p-4 w-full">
+              {active === "profile" && <UserProfile />}
+              {active === "settings" && (
+                <div className="p-4">Settings page coming soon...</div>
+              )}
+              {active === "billing" && (
+                <div className="p-4">Billing page coming soon...</div>
+              )}
+            </SidebarInset>
+          </div>
+        </SidebarProvider>
         <Footer />
       </div>
     </ProtectedRoute>


### PR DESCRIPTION
## Summary
- apply Formik + Zod for validation on signup and login
- update auth pages to match landing page styling
- add sidebar layout on profile page with dummy sections
- implement profile editing via `updateOwnProfile`
- include `formik` dependency in web app

## Testing
- `pnpm run format` *(fails: registry access blocked)*
- `pnpm test` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685af336b768832d91ccd3323b79772c