### PR TITLE
Add initial Strava API integration

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,3 @@
+STRAVA_CLIENT_ID=
+STRAVA_CLIENT_SECRET=
+STRAVA_REDIRECT_URI=http://localhost:4000/api/strava/oauth/callback

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -54,7 +54,8 @@
     "pg": "^8.11.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@graphql-codegen/add": "^4.0.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { AppService } from "./app.service";
 import { DatabaseConfig } from "./config/database.config";
 import { AuthModule } from "./modules/auth/auth.module";
 import { UsersModule } from "./modules/users/users.module";
+import { StravaModule } from "./modules/strava/strava.module";
 
 
 
@@ -54,6 +55,7 @@ export interface GraphQLContext {
     // Feature modules
     AuthModule,
     UsersModule,
+    StravaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/config/database.config.ts
+++ b/apps/api/src/config/database.config.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from "@nestjs/typeorm";
 import { User } from "../entities/user.entity";
+import { StravaAccount } from "../entities/strava-account.entity";
 
 @Injectable()
 export class DatabaseConfig implements TypeOrmOptionsFactory {
@@ -33,7 +34,7 @@ export class DatabaseConfig implements TypeOrmOptionsFactory {
       username,
       password: this.configService.get("DB_PASSWORD", "lominic_password"),
       database,
-      entities: [User],
+      entities: [User, StravaAccount],
       migrations: [__dirname + "/../migrations/*{.ts,.js}"],
       synchronize: nodeEnv !== "production",
       logging: nodeEnv === "development",

--- a/apps/api/src/entities/strava-account.entity.ts
+++ b/apps/api/src/entities/strava-account.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { User } from './user.entity';
+
+@ObjectType()
+@Entity('strava_accounts')
+export class StravaAccount {
+  @Field(() => ID)
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Field(() => ID)
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User, (user) => user.stravaAccounts, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column()
+  accessToken: string;
+
+  @Column()
+  refreshToken: string;
+
+  @Column({ type: 'int' })
+  expiresAt: number;
+
+  @Column({ type: 'int' })
+  athleteId: number;
+}

--- a/apps/api/src/entities/user.entity.ts
+++ b/apps/api/src/entities/user.entity.ts
@@ -6,10 +6,12 @@ import {
   UpdateDateColumn,
   BeforeInsert,
   BeforeUpdate,
+  OneToMany,
 } from 'typeorm'
 import { Field, ObjectType, ID, registerEnumType } from '@nestjs/graphql'
 import * as bcrypt from 'bcryptjs'
 import { Role } from '../common/enums/roles.enum'
+import { StravaAccount } from './strava-account.entity'
 
 registerEnumType(Role, {
   name: 'Role',
@@ -53,6 +55,9 @@ export class User {
   @Field()
   @UpdateDateColumn()
   updatedAt: Date
+
+  @OneToMany(() => StravaAccount, (account) => account.user)
+  stravaAccounts: StravaAccount[]
 
   @BeforeInsert()
   @BeforeUpdate()

--- a/apps/api/src/migrations/1710000001000-CreateStravaAccount.ts
+++ b/apps/api/src/migrations/1710000001000-CreateStravaAccount.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateStravaAccount1710000001000 implements MigrationInterface {
+  name = "CreateStravaAccount1710000001000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "strava_accounts" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "accessToken" character varying NOT NULL,
+        "refreshToken" character varying NOT NULL,
+        "expiresAt" integer NOT NULL,
+        "athleteId" integer NOT NULL,
+        CONSTRAINT "PK_strava_accounts_id" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_strava_accounts_userId" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "strava_accounts"`);
+  }
+}

--- a/apps/api/src/modules/strava/dto/strava-activity.dto.ts
+++ b/apps/api/src/modules/strava/dto/strava-activity.dto.ts
@@ -1,0 +1,22 @@
+import { Field, ObjectType, ID, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class StravaActivity {
+  @Field(() => ID)
+  id: number;
+
+  @Field()
+  name: string;
+
+  @Field(() => Int)
+  distance: number;
+
+  @Field(() => Int)
+  movingTime: number;
+
+  @Field()
+  startDate: string;
+
+  @Field({ nullable: true })
+  description?: string;
+}

--- a/apps/api/src/modules/strava/strava.controller.ts
+++ b/apps/api/src/modules/strava/strava.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { StravaService } from './strava.service';
+
+@Controller('strava')
+export class StravaController {
+  constructor(private readonly stravaService: StravaService) {}
+
+  @Get('connect')
+  async connect(@Query('state') state: string, @Res() res: Response) {
+    const url = this.stravaService.getAuthorizationUrl(state || '');
+    return res.redirect(url);
+  }
+
+  @Get('oauth/callback')
+  async callback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Res() res: Response,
+  ) {
+    await this.stravaService.exchangeToken(code, state);
+    return res.send('Strava connected');
+  }
+}

--- a/apps/api/src/modules/strava/strava.module.ts
+++ b/apps/api/src/modules/strava/strava.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StravaAccount } from '../../entities/strava-account.entity';
+import { StravaService } from './strava.service';
+import { StravaController } from './strava.controller';
+import { StravaResolver } from './strava.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StravaAccount])],
+  providers: [StravaService, StravaResolver],
+  controllers: [StravaController],
+  exports: [StravaService],
+})
+export class StravaModule {}

--- a/apps/api/src/modules/strava/strava.resolver.ts
+++ b/apps/api/src/modules/strava/strava.resolver.ts
@@ -1,0 +1,21 @@
+import { Resolver, Query, Args, Int } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { StravaService } from './strava.service';
+import { StravaActivity } from './dto/strava-activity.dto';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { User } from '../../entities/user.entity';
+import { GqlAuthGuard } from '../../common/guards/gql-auth.guard';
+
+@Resolver()
+@UseGuards(GqlAuthGuard)
+export class StravaResolver {
+  constructor(private readonly stravaService: StravaService) {}
+
+  @Query(() => [StravaActivity])
+  async getStravaActivities(
+    @Args('limit', { type: () => Int, defaultValue: 10 }) limit: number,
+    @CurrentUser() user: User,
+  ) {
+    return this.stravaService.getRecentActivities(user.id, limit);
+  }
+}

--- a/apps/api/src/modules/strava/strava.service.ts
+++ b/apps/api/src/modules/strava/strava.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import fetch from 'node-fetch';
+import { StravaAccount } from '../../entities/strava-account.entity';
+
+@Injectable()
+export class StravaService {
+  constructor(
+    @InjectRepository(StravaAccount)
+    private accounts: Repository<StravaAccount>,
+    private configService: ConfigService,
+  ) {}
+
+  getAuthorizationUrl(state: string): string {
+    const clientId = this.configService.get<string>('STRAVA_CLIENT_ID');
+    const redirectUri = this.configService.get<string>('STRAVA_REDIRECT_URI');
+    const scope = 'activity:read_all';
+    return `https://www.strava.com/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(
+      redirectUri,
+    )}&response_type=code&scope=${scope}&state=${state}`;
+  }
+
+  async exchangeToken(code: string, userId: string): Promise<StravaAccount> {
+    const clientId = this.configService.get<string>('STRAVA_CLIENT_ID');
+    const clientSecret = this.configService.get<string>('STRAVA_CLIENT_SECRET');
+
+    const res = await fetch('https://www.strava.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        grant_type: 'authorization_code',
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Token exchange failed: ${text}`);
+    }
+
+    const data = (await res.json()) as any;
+
+    let account = await this.accounts.findOne({ where: { userId } });
+    if (!account) {
+      account = this.accounts.create({ userId } as any);
+    }
+    account.accessToken = data.access_token;
+    account.refreshToken = data.refresh_token;
+    account.expiresAt = data.expires_at;
+    account.athleteId = data.athlete.id;
+
+    return this.accounts.save(account);
+  }
+
+  async findAccountByUserId(userId: string): Promise<StravaAccount | null> {
+    return this.accounts.findOne({ where: { userId } });
+  }
+
+  private async refreshTokenIfNeeded(account: StravaAccount) {
+    if (account.expiresAt * 1000 > Date.now()) return account;
+
+    const clientId = this.configService.get<string>('STRAVA_CLIENT_ID');
+    const clientSecret = this.configService.get<string>('STRAVA_CLIENT_SECRET');
+
+    const res = await fetch('https://www.strava.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: account.refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    const data = (await res.json()) as any;
+    account.accessToken = data.access_token;
+    account.refreshToken = data.refresh_token;
+    account.expiresAt = data.expires_at;
+    return this.accounts.save(account);
+  }
+
+  async getRecentActivities(userId: string, limit = 10) {
+    const account = await this.findAccountByUserId(userId);
+    if (!account) throw new NotFoundException('Strava account not found');
+    await this.refreshTokenIfNeeded(account);
+
+    const res = await fetch(
+      `https://www.strava.com/api/v3/athlete/activities?per_page=${limit}`,
+      {
+        headers: { Authorization: `Bearer ${account.accessToken}` },
+      },
+    );
+    const data = (await res.json()) as any[];
+    return data.map((a) => ({
+      id: a.id,
+      name: a.name,
+      distance: a.distance,
+      movingTime: a.moving_time,
+      startDate: a.start_date,
+      description: a.description,
+    }));
+  }
+}

--- a/apps/web/src/app/[locale]/client/page.tsx
+++ b/apps/web/src/app/[locale]/client/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { useGetStravaActivitiesQuery } from "@/generated/graphql";
+import { useRBAC } from "@/hooks/use-rbac";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import {
@@ -14,6 +16,13 @@ import { Home, Dumbbell, LineChart, Settings, LogOut } from "lucide-react";
 
 export default function ClientDashboard() {
   const [active, setActive] = useState("overview");
+  const { user } = useRBAC();
+  const { data, loading, error, refetch } = useGetStravaActivitiesQuery({
+    variables: { limit: 5 },
+    skip: !user,
+  });
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001/graphql").replace(/\/?graphql$/, "");
+  const connectUrl = `${apiBase}/strava/connect?state=${user?.id || ""}`;
 
   const renderContent = () => {
     switch (active) {
@@ -40,9 +49,32 @@ export default function ClientDashboard() {
         );
       default:
         return (
-          <div className="p-6">
-            <h2 className="text-2xl font-bold mb-4">Overview</h2>
-            <p className="text-gray-600">Welcome to your dashboard!</p>
+          <div className="p-6 space-y-4">
+            <h2 className="text-2xl font-bold">Overview</h2>
+            {loading && <p>Loading activities...</p>}
+            {error && (
+              <div>
+                <p className="text-gray-600 mb-2">Connect your account to Strava to see recent activities.</p>
+                <a
+                  href={connectUrl}
+                  className="inline-block px-4 py-2 bg-orange-500 text-white rounded"
+                >
+                  Connect with Strava
+                </a>
+              </div>
+            )}
+            {data?.getStravaActivities && (
+              <ul className="space-y-2">
+                {data.getStravaActivities.map((act) => (
+                  <li key={act.id} className="border p-2 rounded">
+                    <div className="font-medium">{act.name}</div>
+                    <div className="text-sm text-gray-600">
+                      {Math.round(act.distance / 1000)} km – {Math.round(act.movingTime / 60)} min
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         );
     }

--- a/apps/web/src/generated/graphql.ts
+++ b/apps/web/src/generated/graphql.ts
@@ -91,11 +91,16 @@ export type Query = {
   me: User;
   user: User;
   users: Array<User>;
+  getStravaActivities: Array<StravaActivity>;
 };
 
 
 export type QueryUserArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type QueryGetStravaActivitiesArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegisterInput = {
@@ -129,6 +134,16 @@ export type User = {
   lastName: Scalars['String']['output'];
   role: Role;
   updatedAt: Scalars['DateTime']['output'];
+};
+
+export type StravaActivity = {
+  __typename?: 'StravaActivity';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  distance: Scalars['Int']['output'];
+  movingTime: Scalars['Int']['output'];
+  startDate: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
 };
 
 export type LoginMutationVariables = Exact<{
@@ -199,6 +214,12 @@ export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type MeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, email: string, firstName: string, lastName: string, role: Role, isEmailVerified: boolean, createdAt: string, updatedAt: string } };
+
+export type GetStravaActivitiesQueryVariables = Exact<{
+  limit: Scalars['Int']['input'];
+}>;
+
+export type GetStravaActivitiesQuery = { __typename?: 'Query', getStravaActivities: Array<{ __typename?: 'StravaActivity', id: string, name: string, distance: number, movingTime: number, startDate: string, description?: string | null }> };
 
 
 export const LoginDocument = gql`
@@ -639,3 +660,48 @@ export type MeQueryHookResult = ReturnType<typeof useMeQuery>;
 export type MeLazyQueryHookResult = ReturnType<typeof useMeLazyQuery>;
 export type MeSuspenseQueryHookResult = ReturnType<typeof useMeSuspenseQuery>;
 export type MeQueryResult = ApolloReactCommon.QueryResult<MeQuery, MeQueryVariables>;
+export const GetStravaActivitiesDocument = gql`
+    query GetStravaActivities($limit: Int!) {
+  getStravaActivities(limit: $limit) {
+    id
+    name
+    distance
+    movingTime
+    startDate
+    description
+  }
+}
+    `;
+
+/**
+ * __useGetStravaActivitiesQuery__
+ *
+ * To run a query within a React component, call `useGetStravaActivitiesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStravaActivitiesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetStravaActivitiesQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *   },
+ * });
+ */
+export function useGetStravaActivitiesQuery(baseOptions: ApolloReactHooks.QueryHookOptions<GetStravaActivitiesQuery, GetStravaActivitiesQueryVariables> & ({ variables: GetStravaActivitiesQueryVariables; skip?: boolean; } | { skip: boolean; })) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useQuery<GetStravaActivitiesQuery, GetStravaActivitiesQueryVariables>(GetStravaActivitiesDocument, options);
+      }
+export function useGetStravaActivitiesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetStravaActivitiesQuery, GetStravaActivitiesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useLazyQuery<GetStravaActivitiesQuery, GetStravaActivitiesQueryVariables>(GetStravaActivitiesDocument, options);
+        }
+export function useGetStravaActivitiesSuspenseQuery(baseOptions?: ApolloReactHooks.SkipToken | ApolloReactHooks.SuspenseQueryHookOptions<GetStravaActivitiesQuery, GetStravaActivitiesQueryVariables>) {
+          const options = baseOptions === ApolloReactHooks.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return ApolloReactHooks.useSuspenseQuery<GetStravaActivitiesQuery, GetStravaActivitiesQueryVariables>(GetStravaActivitiesDocument, options);
+        }
+export type GetStravaActivitiesQueryHookResult = ReturnType<typeof useGetStravaActivitiesQuery>;
+export type GetStravaActivitiesLazyQueryHookResult = ReturnType<typeof useGetStravaActivitiesLazyQuery>;
+export type GetStravaActivitiesSuspenseQueryHookResult = ReturnType<typeof useGetStravaActivitiesSuspenseQuery>;
+export type GetStravaActivitiesQueryResult = ApolloReactCommon.QueryResult<GetStravaActivitiesQuery, GetStravaActivitiesQueryVariables>;

--- a/apps/web/src/graphql/strava.graphql
+++ b/apps/web/src/graphql/strava.graphql
@@ -1,0 +1,10 @@
+query GetStravaActivities($limit: Int!) {
+  getStravaActivities(limit: $limit) {
+    id
+    name
+    distance
+    movingTime
+    startDate
+    description
+  }
+}


### PR DESCRIPTION
## Summary
- create `.env.example` with Strava variables
- add `StravaAccount` entity and migration
- wire up Strava module with controller, service, resolver and DTOs
- register `StravaModule` in `AppModule`
- update database config to include new entity
- link `StravaAccount` relation in `User`
- add `node-fetch` dependency
- expose activities query on the frontend and show a Strava connect button

## Testing
- `pnpm lint` *(fails: Request was cancelled - registry access blocked)*
- `pnpm test` *(fails: Request was cancelled - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d910dec78832d91b7b97b3139e97a